### PR TITLE
Rename rtl_* to rx_* since no longer tied to RTL library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 
 **/*.o
 **/*.a
-rtl_fm
-rtl_power
-rtl_sdr
+rx_fm
+rx_power
+rx_sdr

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,22 @@ CC=cc
 CFLAGS=-g
 LIBS=$(shell pkg-config --cflags --libs SoapySDR)
 
-all: rtl_fm rtl_power rtl_sdr
+all: rx_fm rx_power rx_sdr
 
 convenience.o: src/convenience/convenience.c src/convenience/convenience.h
 	$(CC) $(CFLAGS) -c src/convenience/convenience.c -o convenience.o
 
-rtl_fm: convenience.o src/rtl_fm.c
-	$(CC) $(CFLAGS) $(LIBS) src/rtl_fm.c convenience.o -o rtl_fm
+rx_fm: convenience.o src/rtl_fm.c
+	$(CC) $(CFLAGS) $(LIBS) src/rtl_fm.c convenience.o -o rx_fm
 
-rtl_power: convenience.o src/rtl_power.c
-	$(CC) $(CFLAGS) $(LIBS) src/rtl_power.c convenience.o -o rtl_power
+rx_power: convenience.o src/rtl_power.c
+	$(CC) $(CFLAGS) $(LIBS) src/rtl_power.c convenience.o -o rx_power
 
-rtl_sdr: convenience.o src/rtl_sdr.c
-	$(CC) $(CFLAGS) $(LIBS) src/rtl_sdr.c convenience.o -o rtl_sdr
+rx_sdr: convenience.o src/rtl_sdr.c
+	$(CC) $(CFLAGS) $(LIBS) src/rtl_sdr.c convenience.o -o rx_sdr
 
 clean:
-	rm -f *.o rtl_fm rtl_power rtl_sdr
+	rm -f *.o rx_fm rx_power rx_sdr
 
 test:
-	./rtl_fm -M wbfm -f 107.7M | play -r 32k -t raw -e s -b 16 -c 1 -V1 -
+	./rx_fm -M wbfm -f 107.3M | play -r 32k -t raw -e s -b 16 -c 1 -V1 -

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# rtl\_tools
+# rx\_tools
 
-Standalone versions of `rtl_fm`, `rtl_power`, and `rtl_sdr` based on [librtlsdr](https://github.com/librtlsdr/librtlsdr),
+`rx_fm`, `rx_power`, and `rx_sdr` tools for receiving data from SDRs,
+based on `rtl_fm`, `rtl_power`, and `rtl_sdr` from [librtlsdr](https://github.com/librtlsdr/librtlsdr),
 but using the [SoapySDR](https://github.com/pothosware/SoapySDR) vendor-neutral SDR support library instead, intended
 to support a wider range of devices than RTL-SDR.
 
@@ -14,11 +15,11 @@ to support a wider range of devices than RTL-SDR.
 
 After building, these binaries should then be available at the root directory:
 
-* `rtl_fm`: demodulator for FM and other modes, see [rtl\_fm guide](http://kmkeen.com/rtl-demod-guide/index.html)
+* `rx_fm` (based on `rtl_fm`): demodulator for FM and other modes, see [rtl\_fm guide](http://kmkeen.com/rtl-demod-guide/index.html)
 
-* `rtl_power`: FFT logger, see [rtl\_power](http://kmkeen.com/rtl-power/)
+* `rx_power` (based on `rtl_power`): FFT logger, see [rtl\_power](http://kmkeen.com/rtl-power/)
 
-* `rtl_sdr`: emits raw I/Q data
+* `rx_sdr` (based on `rtl_sdr`): emits raw I/Q data
 
 ### Not included
 


### PR DESCRIPTION
The names rtl_* no longer are accurate after https://github.com/rxseger/rtl_tools/pull/1 Port from librtlsdr to SoapySDR API, since they interface with the SoapySDR library instead of librtlsdr, potentially other SDR devices can be supported, non-RTL-SDRs.

Renamed rtl_fm/rtl_power/rtl_sdr to rx_fm/rx_power/rx_sdr to clarify this distinction, rx = receive from an arbitrary SDR device. To preserve git history conveniently (without git --follow), keeping the same source code filenames, but updating the compiled binary output files to rx_*.